### PR TITLE
Add max db.statement length

### DIFF
--- a/lib/patches/sequelize.js
+++ b/lib/patches/sequelize.js
@@ -11,9 +11,13 @@ module.exports = function (object) {
       } else if (sql && sql.split(' ').length > 0) {
         spanName = 'SQL ' + sql.split(' ')[0]
       }
+
+      const length = 253 // 256 - 3 points
+      const trimmedSQL = sql.length > length ? sql.substring(0, length - 3) + '...' : sql
+
       let span = parent.startSpan(spanName, {
         'db.instance': this.config.database,
-        'db.statement': sql,
+        'db.statement': trimmedSQL,
         'db.type': 'sql',
         'db.user': this.config.username,
         'span.kind': 'client'


### PR DESCRIPTION
Sequalize normally creates big queries, because making spans bigger than the UDP max length and producing an error like:
```
Failed to flush spans in reporter: error sending spans over UDP: Error: send EMSGSIZE localhost:6832, packet size: 13322, bytes sent: 13322
```
This PR solves the problem.
