### PR TITLE
Create a wrap for promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const patch = require('./lib/patch')
 const tracer = require('./lib/core/tracer')
 const util = require('util')
+const promises = require('./lib/helpers/promises')
 
 patch()
 
@@ -8,7 +9,7 @@ module.exports = {
   configure: tracer.configure,
   currentSpan: tracer.currentSpan,
   startSpan: tracer.startSpan,
-  wrapPromise: tracer.wrapPromise,
+  wrapPromise: promises.wrapPromise,
 
   /**
     * @deprecated since version 1.1.0

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = {
   configure: tracer.configure,
   currentSpan: tracer.currentSpan,
   startSpan: tracer.startSpan,
+  wrapPromise: tracer.wrapPromise,
 
   /**
     * @deprecated since version 1.1.0

--- a/lib/core/tracer.js
+++ b/lib/core/tracer.js
@@ -56,6 +56,9 @@ function configure (opts) {
   instance = factory(opts)
 }
 
+// If you don't use the promise wrapper, all spans below it will be below to
+// the parent span. If you use it, a new span will be created and all spans
+// inside it will be below it.
 function wrapPromise (fn, name) {
   return (...args) => {
     let parent = currentSpan()

--- a/lib/core/tracer.js
+++ b/lib/core/tracer.js
@@ -56,8 +56,30 @@ function configure (opts) {
   instance = factory(opts)
 }
 
+function wrapPromise (fn, name) {
+  return (...args) => {
+    let parent = currentSpan()
+    let span = parent.startSpan(name, {})
+    const promise = span.propagate(() => fn(...args))
+
+    if (!promise.then) {
+      throw new Error('Expected function to return a Promise!')
+    }
+    const resolve = (ret) => {
+      span.finish()
+      return ret
+    }
+    const reject = (ret) => {
+      span.finish(ret)
+      throw ret
+    }
+    return promise.then(resolve, reject)
+  }
+}
+
 module.exports = {
   startSpan,
   currentSpan,
-  configure
+  configure,
+  wrapPromise
 }

--- a/lib/core/tracer.js
+++ b/lib/core/tracer.js
@@ -56,33 +56,8 @@ function configure (opts) {
   instance = factory(opts)
 }
 
-// If you don't use the promise wrapper, all spans below it will be below to
-// the parent span. If you use it, a new span will be created and all spans
-// inside it will be below it.
-function wrapPromise (fn, name) {
-  return (...args) => {
-    let parent = currentSpan()
-    let span = parent.startSpan(name, {})
-    const promise = span.propagate(() => fn(...args))
-
-    if (!promise.then) {
-      throw new Error('Expected function to return a Promise!')
-    }
-    const resolve = (ret) => {
-      span.finish()
-      return ret
-    }
-    const reject = (ret) => {
-      span.finish(ret)
-      throw ret
-    }
-    return promise.then(resolve, reject)
-  }
-}
-
 module.exports = {
   startSpan,
   currentSpan,
-  configure,
-  wrapPromise
+  configure
 }

--- a/lib/helpers/promises.js
+++ b/lib/helpers/promises.js
@@ -1,0 +1,29 @@
+const tracer = require('../core/tracer')
+
+// If you don't use the promise wrapper, all spans below it will be below to
+// the parent span. If you use it, a new span will be created and all spans
+// inside it will be below it.
+function wrapPromise (fn, name) {
+  return (...args) => {
+    let parent = tracer.currentSpan()
+    let span = parent.startSpan(name, {})
+    const promise = span.propagate(() => fn(...args))
+
+    if (!promise.then) {
+      throw new Error('Expected function to return a Promise!')
+    }
+    const resolve = (ret) => {
+      span.finish()
+      return ret
+    }
+    const reject = (ret) => {
+      span.finish(ret)
+      throw ret
+    }
+    return promise.then(resolve, reject)
+  }
+}
+
+module.exports = {
+  wrapPromise
+}


### PR DESCRIPTION
With this new method, we can call a promise and all the functions inside it will be inside an span. For example:

```
const a1 = jaeger.wrapPromise(promise1, 'CONFIGS')
const a2 = jaeger.wrapPromise(promise2, 'AB TESTS')
const a3 = jaeger.wrapPromise(promise3, 'ARC')
Promise.all([a1, a2, a3])
```
Will produce the following traces:

<img width="478" alt="Screen Shot 2019-08-12 at 14 07 16" src="https://user-images.githubusercontent.com/1574428/62883546-aa89f000-bd0a-11e9-94bc-3362955a8956.png">
