### PR TITLE
Make it possible to blacklist patches via environment variable

### DIFF
--- a/lib/patch.js
+++ b/lib/patch.js
@@ -10,6 +10,8 @@ module.exports = function () {
     return
   }
 
+  const blacklist = (process.env['JAEGER_PATCH_BLACKLIST'] || '').split(',');
+  
   util.wrap(Module, '_load', original => {
     return function (file) {
       let object = original.apply(this, arguments)
@@ -19,7 +21,7 @@ module.exports = function () {
         return object
       }
 
-      if (patch) {
+      if (patch && !blacklist.includes(file)) {
         patch(object)
         object.__patched = true
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaeger-tracer-node",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Jaeger node client extended with implicit context propagation and external library patches",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is a work-around to the problem caused by the automatic patching of a more recent version of MongoDB.